### PR TITLE
fix for Xcode 6 setWeek: warning

### DIFF
--- a/CupertinoYankee/NSDate+CupertinoYankee.m
+++ b/CupertinoYankee/NSDate+CupertinoYankee.m
@@ -58,7 +58,7 @@
     NSCalendar *calendar = [NSCalendar currentCalendar];
     
     NSDateComponents *components = [[NSDateComponents alloc] init];
-    [components setWeek:1];
+    [components setWeekOfMonth:1];
     
     return [[calendar dateByAddingComponents:components toDate:[self beginningOfWeek] options:0] dateByAddingTimeInterval:-1];
 }


### PR DESCRIPTION
Xcode 6 gives a warning on setWeek:, replaced with setWeekOfMonth: and ran tests
