### PR TITLE
added Next and Previous Methods for Day, Week, Month and Year

### DIFF
--- a/CupertinoYankee.podspec
+++ b/CupertinoYankee.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'CupertinoYankee'
-  s.version  = '1.0.2'
+  s.version  = '1.1.0'
   s.license  = 'MIT'
-  s.summary  = 'An NSDate Category With Locale-Aware Calculations for Beginning & End of Day, Week, Month, and Year.'
+  s.summary  = 'An NSDate Category With Locale-Aware Calculations for Beginning, End, Next & Previous of Day, Week, Month, and Year'
   s.homepage = 'https://github.com/mattt/CupertinoYankee'
   s.social_media_url = 'https://twitter.com/mattt'
   s.authors  = {'Mattt Thompson' => 'm@mattt.me'}
-  s.source   = { :git => 'https://github.com/mattt/CupertinoYankee.git', :tag => '1.0.2' }
+  s.source   = { :git => 'https://github.com/mattt/CupertinoYankee.git', :tag => s.version.to_s }
   s.source_files = 'CupertinoYankee/NSDate+CupertinoYankee.{h,m}'
   s.requires_arc = true
 end

--- a/CupertinoYankee/NSDate+CupertinoYankee.h
+++ b/CupertinoYankee/NSDate+CupertinoYankee.h
@@ -43,6 +43,20 @@
  */
 - (NSDate *)endOfDay;
 
+///-----------------------------------------
+/// @name Calculating Next / Previous Day
+///-----------------------------------------
+
+/**
+ Returns a new date that is one day (24 hours) ahead
+ */
+- (NSDate *)nextDay;
+
+/**
+ Returns a new date that is one day (24 hours) before
+ */
+- (NSDate *)previousDay;
+
 ///------------------------------------------
 /// @name Calculating Beginning / End of Week
 ///------------------------------------------
@@ -56,6 +70,20 @@
  Returns a new date with last second of the last weekday of the receiver, taking into account the current calendar's `firstWeekday` property.
  */
 - (NSDate *)endOfWeek;
+
+///------------------------------------------
+/// @name Calculating Next / Previous Week
+///------------------------------------------
+
+/**
+ Returns a new date that is one week (7 days) ahead
+ */
+- (NSDate *)nextWeek;
+
+/**
+ Returns a new date that is one week (7 days) before
+ */
+- (NSDate *)previousWeek;
 
 ///-------------------------------------------
 /// @name Calculating Beginning / End of Month
@@ -71,6 +99,20 @@
  */
 - (NSDate *)endOfMonth;
 
+///-------------------------------------------
+/// @name Calculating Next / Previous Month
+///-------------------------------------------
+
+/**
+ Returns a new date that is one month ahead
+ */
+- (NSDate *)nextMonth;
+
+/**
+ Returns a new date that is one month before
+ */
+- (NSDate *)previousMonth;
+
 ///------------------------------------------
 /// @name Calculating Beginning / End of Year
 ///------------------------------------------
@@ -84,5 +126,19 @@
  Returns a new date with the last second of the last day of the year of the receiver.
  */
 - (NSDate *)endOfYear;
+
+///------------------------------------------
+/// @name Calculating Next / Previous Year
+///------------------------------------------
+
+/**
+ Returns a new date that is one year ahead
+ */
+- (NSDate *)nextYear;
+
+/**
+ Returns a new date that is one year before
+ */
+- (NSDate *)previousYear;
 
 @end

--- a/CupertinoYankee/NSDate+CupertinoYankee.m
+++ b/CupertinoYankee/NSDate+CupertinoYankee.m
@@ -63,6 +63,26 @@
     return [[calendar dateByAddingComponents:components toDate:[self beginningOfDay] options:0] dateByAddingTimeInterval:-1];
 }
 
+- (NSDate *)nextDay {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.day = 1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
+- (NSDate *)previousDay {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.day = -1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
 #pragma mark -
 
 - (NSDate *)beginningOfWeek {
@@ -85,6 +105,26 @@
     return [[calendar dateByAddingComponents:components toDate:[self beginningOfWeek] options:0] dateByAddingTimeInterval:-1];
 }
 
+- (NSDate *)nextWeek {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.weekOfMonth = 1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
+- (NSDate *)previousWeek {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.weekOfMonth = -1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
 #pragma mark -
 
 - (NSDate *)beginningOfMonth {
@@ -104,6 +144,26 @@
     return [[calendar dateByAddingComponents:components toDate:[self beginningOfMonth] options:0] dateByAddingTimeInterval:-1];
 }
 
+- (NSDate *)nextMonth {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.month = 1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
+- (NSDate *)previousMonth {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.month = -1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
 #pragma mark -
 
 - (NSDate *)beginningOfYear {
@@ -121,6 +181,27 @@
     components.year = 1;
 
     return [[calendar dateByAddingComponents:components toDate:[self beginningOfYear] options:0] dateByAddingTimeInterval:-1];
+}
+
+- (NSDate *)nextYear {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.year = 1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
+}
+
+
+- (NSDate *)previousYear {
+    
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [[NSDateComponents alloc] init];
+    components.year = -1;
+    
+    return [calendar dateByAddingComponents:components toDate:self options:0];
 }
 
 @end

--- a/Example/Cupertino Yankee Example/main.m
+++ b/Example/Cupertino Yankee Example/main.m
@@ -27,15 +27,23 @@
 int main (int argc, const char * argv[]) {
     @autoreleasepool {
         NSDate *date = [NSDate date];
-        NSLog(@"Current Time: %@", date);
-        NSLog(@"Beginning of Day: %@", [date beginningOfDay]);
-        NSLog(@"End of Day: %@", [date endOfDay]);
-        NSLog(@"Beginning of Week: %@", [date beginningOfWeek]);
-        NSLog(@"End of Week: %@", [date endOfWeek]);
+        NSLog(@"Current Time:       %@", date);
+        NSLog(@"Beginning of Day:   %@", [date beginningOfDay]);
+        NSLog(@"End of Day:         %@", [date endOfDay]);
+        NSLog(@"Next Day:           %@", [date nextDay]);
+        NSLog(@"Previous Day:       %@", [date previousDay]);
+        NSLog(@"Beginning of Week:  %@", [date beginningOfWeek]);
+        NSLog(@"End of Week:        %@", [date endOfWeek]);
+        NSLog(@"Next Week:          %@", [date nextWeek]);
+        NSLog(@"Previous Week:      %@", [date previousWeek]);
         NSLog(@"Beginning of Month: %@", [date beginningOfMonth]);
-        NSLog(@"End of Month: %@", [date endOfMonth]);
-        NSLog(@"Beginning of Year: %@", [date beginningOfYear]);
-        NSLog(@"End of Year: %@", [date endOfYear]);
+        NSLog(@"End of Month:       %@", [date endOfMonth]);
+        NSLog(@"Next Month:         %@", [date nextMonth]);
+        NSLog(@"Previous Month:     %@", [date previousMonth]);
+        NSLog(@"Beginning of Year:  %@", [date beginningOfYear]);
+        NSLog(@"End of Year:        %@", [date endOfYear]);
+        NSLog(@"Next Year:          %@", [date nextYear]);
+        NSLog(@"Previous Year:      %@", [date previousYear]);
     }
     
     return 0;

--- a/Example/Cupertino Yankee Tests/CupertinoYankeeTests.m
+++ b/Example/Cupertino Yankee Tests/CupertinoYankeeTests.m
@@ -67,6 +67,16 @@ static NSDate * CYDateFromString(NSString *string) {
 	XCTAssertEqualObjects([self.date endOfDay], CYDateFromString(@"2012-07-19 23:59:59 +0000"));
 }
 
+- (void)testNextDay {
+    
+    XCTAssertEqualObjects([self.date nextDay], CYDateFromString(@"2012-07-20 14:30:45 +0000"));
+}
+
+- (void)testPreviousDay {
+    
+    XCTAssertEqualObjects([self.date previousDay], CYDateFromString(@"2012-07-18 14:30:45 +0000"));
+}
+
 - (void)testBeginningOfWeekIsFirstWeekday {
     NSDate *today = [NSDate date];
     NSDate *beginningOfTodaysWeek = [today beginningOfWeek];
@@ -79,11 +89,19 @@ static NSDate * CYDateFromString(NSString *string) {
 }
 
 - (void)testBeginningOfWeek {
-	XCTAssertEqualObjects([self.date beginningOfWeek], CYDateFromString(@"2012-07-15 00:00:00 +0000"));
+	XCTAssertEqualObjects([self.date beginningOfWeek], CYDateFromString(@"2012-07-16 00:00:00 +0000"));
 }
 
 - (void)testEndOfWeek {
-	XCTAssertEqualObjects([self.date endOfWeek], CYDateFromString(@"2012-07-21 23:59:59 +0000"));
+	XCTAssertEqualObjects([self.date endOfWeek], CYDateFromString(@"2012-07-22 23:59:59 +0000"));
+}
+
+- (void)testNextWeek {
+    XCTAssertEqualObjects([self.date nextWeek], CYDateFromString(@"2012-07-26 14:30:45 +0000"));
+}
+
+- (void)testPreviousWeek {
+    XCTAssertEqualObjects([self.date previousWeek], CYDateFromString(@"2012-07-12 14:30:45 +0000"));
 }
 
 - (void)testBeginningOfMonth {
@@ -94,12 +112,28 @@ static NSDate * CYDateFromString(NSString *string) {
 	XCTAssertEqualObjects([self.date endOfMonth], CYDateFromString(@"2012-07-31 23:59:59 +0000"));
 }
 
+- (void)testNextMonth {
+    XCTAssertEqualObjects([self.date nextMonth], CYDateFromString(@"2012-08-19 14:30:45 +0000"));
+}
+
+- (void)testPreviousMonth {
+    XCTAssertEqualObjects([self.date previousMonth], CYDateFromString(@"2012-06-19 14:30:45 +0000"));
+}
+
 - (void)testBeginningOfYear {
 	XCTAssertEqualObjects([self.date beginningOfYear], CYDateFromString(@"2012-01-01 00:00:00 +0000"));
 }
 
 - (void)testEndOfYear {
 	XCTAssertEqualObjects([self.date endOfYear], CYDateFromString(@"2012-12-31 23:59:59 +0000"));
+}
+
+- (void)testNextYear {
+    XCTAssertEqualObjects([self.date nextYear], CYDateFromString(@"2013-07-19 14:30:45 +0000"));
+}
+
+- (void)testPreviousYear {
+    XCTAssertEqualObjects([self.date previousYear], CYDateFromString(@"2011-07-19 14:30:45 +0000"));
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Cupertino Yankee in Scott Forstall's Court
 
-**An NSDate Category With Locale-Aware Calculations for Beginning & End of Day, Week, Month, and Year**
+**An NSDate Category With Locale-Aware Calculations for Beginning, End, Next & Previous of Day, Week, Month, and Year**
 
 > **Thompson's Law**: Any code that performs sufficiently complex date calculations using naïve arithmetic means has a non-zero chance of causing a Y2K-style collapse of the global technology infrastructure.
 
@@ -13,29 +13,46 @@ Anyway, this library uses `NSCalendar` and `NSDateComponents` exclusively for da
 ## Usage
 
 ``` objective-c
-NSLog(@"Current Time: %@", date);
-NSLog(@"Beginning of Day:%@", [date beginningOfDay]);
-NSLog(@"End of Day:%@", [date endOfDay]);
-NSLog(@"Beginning of Week:%@", [date beginningOfWeek]);
-NSLog(@"End of Week:%@", [date endOfWeek]);
-NSLog(@"Beginning of Month:%@", [date beginningOfMonth]);
-NSLog(@"End of Month:%@", [date endOfMonth]);
-NSLog(@"Beginning of Year:%@", [date beginningOfYear]);
-NSLog(@"End of Year:%@", [date endOfYear]);
+NSLog(@"Current Time:       %@", date);
+NSLog(@"Beginning of Day:   %@", [date beginningOfDay]);
+NSLog(@"End of Day:         %@", [date endOfDay]);
+NSLog(@"Next Day:           %@", [date nextDay]);
+NSLog(@"Previous Day:       %@", [date previousDay]);
+NSLog(@"Beginning of Week:  %@", [date beginningOfWeek]);
+NSLog(@"End of Week:        %@", [date endOfWeek]);
+NSLog(@"Next Week:          %@", [date nextWeek]);
+NSLog(@"Previous Week:      %@", [date previousWeek]);
+NSLog(@"Beginning of Month: %@", [date beginningOfMonth]);
+NSLog(@"End of Month:       %@", [date endOfMonth]);
+NSLog(@"Next Month:         %@", [date nextMonth]);
+NSLog(@"Previous Month:     %@", [date previousMonth]);
+NSLog(@"Beginning of Year:  %@", [date beginningOfYear]);
+NSLog(@"End of Year:        %@", [date endOfYear]);
+NSLog(@"Next Year:          %@", [date nextYear]);
+NSLog(@"Previous Year:      %@", [date previousYear]);
 ```
 
 Result (Note the Time Zone and Daylight Savings Offsets)
 
 ```
-Current Time: 2013-10-19 13:29:26 +0000
-Beginning of Day: 2013-10-18 22:00:00 +0000
-End of Day: 2013-10-19 21:59:59 +0000
-Beginning of Week: 2013-10-12 22:00:00 +0000
-End of Week: 2013-10-19 21:59:59 +0000
-Beginning of Month: 2013-09-30 22:00:00 +0000
-End of Month: 2013-10-31 22:59:59 +0000
-Beginning of Year: 2012-12-31 23:00:00 +0000
-End of Year: 2013-12-31 22:59:59 +0000
+Current Time:       2015-07-13 14:26:08 +0000
+Beginning of Day:   2015-07-12 22:00:00 +0000
+End of Day:         2015-07-13 21:59:59 +0000
+Next Day:           2015-07-14 14:26:08 +0000
+Previous Day:       2015-07-12 14:26:08 +0000
+Beginning of Week:  2015-07-12 22:00:00 +0000
+End of Week:        2015-07-19 21:59:59 +0000
+Next Week:          2015-07-20 14:26:08 +0000
+Previous Week:      2015-07-06 14:26:08 +0000
+Beginning of Month: 2015-06-30 22:00:00 +0000
+End of Month:       2015-07-31 21:59:59 +0000
+Next Month:         2015-08-13 14:26:08 +0000
+Previous Month:     2015-06-13 14:26:08 +0000
+Beginning of Year:  2014-12-31 23:00:00 +0000
+End of Year:        2015-12-31 22:59:59 +0000
+Next Year:          2016-07-13 14:26:08 +0000
+Previous Year:      2014-07-13 14:26:08 +0000
+
 ```
 
 ## Contact


### PR DESCRIPTION
I added new methods to calculate the next and previous of the day, week, month and year.
Also updated the tests, example, README and podspec (bumped version to 1.1.0).

Just let me know if need to change something.
