### PR TITLE
Fix: Gregorian calendar and NSLocale with Monday as first day of week

### DIFF
--- a/CupertinoYankee/NSDate+CupertinoYankee.m
+++ b/CupertinoYankee/NSDate+CupertinoYankee.m
@@ -71,6 +71,9 @@
     NSDateComponents *components = [calendar components:CYCalendarUnitYear | CYCalendarUnitMonth | CYCalendarUnitWeekday | CYCalendarUnitDay fromDate:self];
 
     NSInteger offset = components.weekday - (NSInteger)calendar.firstWeekday;
+	if (offset < 0) {
+		offset += calendar.weekdaySymbols.count;
+	}
     components.day = components.day - offset;
 
     return [calendar dateFromComponents:components];


### PR DESCRIPTION
In Serbian, Monday is first day of week. With Serbian Latin, a Gregorian calendar is used and thus components.weekday for Monday returns 2. Thus if today is Sunday, existing code returns offset -1, which sets beginningOfWeek as tomorrow Monday, not that week's Monday.

```
(lldb) po self
2015-12-27 10:35:41 +0000

(lldb) po components
<NSDateComponents: 0x125cec410>
    Calendar Year: 2015
    Month: 12
    Leap month: no
    Day: 27
    Weekday: 1

(lldb) po calendar.firstWeekday
2

(lldb) p offset
(NSInteger) $3 = -1
(lldb) 
```

This fix detects that and rolls back a week.
